### PR TITLE
Handle List SubObject

### DIFF
--- a/src/queryBuilder.js
+++ b/src/queryBuilder.js
@@ -33,18 +33,16 @@ export const isSubObject = field => {
     );
 };
 
-const getType = field => {
-    if (
-        field.type.kind === TypeKind.LIST ||
-        field.type.kind === TypeKind.NON_NULL
-    ) {
-        return field.type.ofType;
-    }
-    return field.type;
+const getType = (type) => {
+  if (type.kind === TypeKind.NON_NULL || type.kind === TypeKind.LIST) {
+    return getFinalType(type.ofType);
+  }
+
+  return type;
 };
 
 const isResource = (field, resources) => {
-    const type = getType(field);
+    const type = getType(field.type);
     return resources.some(r => r.type.name === type.name);
 };
 
@@ -63,7 +61,7 @@ const buildFieldList = (
         .map(field => {
             try {
                 if (isSubObject(field, types) && depth < 8) {
-                    let typeToCheck = getType(field);
+                    let typeToCheck = getType(field.type);
                     if (isResource(field, resources)) {
                         const type = types.find(
                             t => t.name === typeToCheck.name


### PR DESCRIPTION
Hi, thanks a lot for this repo. 
I believe it is a good start for a `graphql-compose-mongoose` data provider for `react-admin`.

Here is a little improvement on List SubObject

### The problem
For a `field` like that
```
const field = {
  args: []
  deprecationReason: null
  description: null
  isDeprecated: false
  name: "items"
  type: {
    kind: "NON_NULL"
    name: null
    ofType: {
      kind: "LIST", 
      name: null,
      ofType: { kind: "OBJECT", name: "OrderItems" }
    }
  }
}
```
`getType(field)` will return `{ kind: "LIST", name: null, ofType: { kind: "OBJECT", name: "OrderItems" }` instead of `{ kind: "OBJECT", name: "OrderItems" }`

So the new version of `getType` is mostly based on [react-admin](https://github.com/marmelab/react-admin)'s [getFinalType](https://github.com/marmelab/react-admin/blob/master/packages/ra-data-graphql-simple/src/getFinalType.js)